### PR TITLE
Remove normal attribute completely

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,9 +6,6 @@ Chef::Log.debug "Loaded settings: #{settings.inspect}"
 # Initialize the node attributes with node attributes merged with data bag attributes
 #
 node.default[:elasticsearch] ||= {}
-node.normal[:elasticsearch]  ||= {}
-node.normal[:elasticsearch]    = DeepMerge.merge(node.default[:elasticsearch].to_hash, node.normal[:elasticsearch].to_hash)
-node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_hash, settings.to_hash)
 
 
 # === VERSION AND LOCATION


### PR DESCRIPTION
They are not used today apparently and prevent deployment to be checked
correctly

Change-Id: I41ccff22391f9511bd525621a1b2c3e3238804ee